### PR TITLE
Update v3_delete_alias.go 修复平台值默认未传递时，极光响应错误问题

### DIFF
--- a/api/jpush/device/v3_delete_alias.go
+++ b/api/jpush/device/v3_delete_alias.go
@@ -39,10 +39,14 @@ func (d *apiv3) DeleteAlias(ctx context.Context, alias string, plats ...platform
 		return nil, errors.New("`alias` cannot be empty")
 	}
 
+	var platformQuery string
+	if len(plats) > 0 {
+		platformQuery="?platform=" + platform.Concat(plats, ",")
+	}
 	req := &api.Request{
 		Method: http.MethodDelete,
 		Proto:  d.proto,
-		URL:    d.host + "/v3/aliases/" + alias + "?platform=" + platform.Concat(plats, ","),
+		URL:    d.host + "/v3/aliases/" + alias + platformQuery,
 		Auth:   d.auth,
 	}
 	resp, err := d.client.Request(ctx, req)


### PR DESCRIPTION
修复删除别名时，platform参数为空值时，极光校验失败问题，当参数未传递时,默认不组装参数
{
    "error": {
        "code": 7002,
        "message": "Invalid platform value, must be one or more in 'android', 'ios', 'quickapp' 'hmos'."
    }
}